### PR TITLE
Fix spawnpoints for defenders in Demolition

### DIFF
--- a/iw4x/iw4x_00/maps/mp/gametypes/dd.gsc
+++ b/iw4x/iw4x_00/maps/mp/gametypes/dd.gsc
@@ -248,9 +248,9 @@ onStartGameType()
 		maps\mp\gametypes\_spawnlogic::placeSpawnPoints( "mp_dd_spawn_attacker_start" );
 	
 	if ( getDvar( "mapname" ) == "mp_shipment_long" )
-		level.spawn_attackers = maps\mp\gametypes\_spawnlogic::getSpawnpointArray( "mp_cha_spawn_axis" );
+		level.spawn_defenders = maps\mp\gametypes\_spawnlogic::getSpawnpointArray( "mp_cha_spawn_axis" );
 	else
-		level.spawn_attackers = maps\mp\gametypes\_spawnlogic::getSpawnpointArray( "mp_dd_spawn_defender" );
+		level.spawn_defenders = maps\mp\gametypes\_spawnlogic::getSpawnpointArray( "mp_dd_spawn_defender" );
 		
 	level.spawn_defenders_a = maps\mp\gametypes\_spawnlogic::getSpawnpointArray( "mp_dd_spawn_defender_a" );
 	level.spawn_defenders_a = array_combine( level.spawn_defenders, level.spawn_defenders_a );


### PR DESCRIPTION
Fixing a somewhat of an old regression where the defender spawnpoints are not set at all in dd.gsc. This has lead to the somewhat infamous "defenders die but respawn in the exact place they died" bug in Demolition.

I believe this fix should be sufficient for fixing the problem. The attacker spawnpoints are still being set on lines 261 and 263, so it looks like this might have just been a typo.